### PR TITLE
Add localized help button in profile menu

### DIFF
--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -819,11 +819,25 @@ async def rules_callback_handler(call: CallbackQuery):
     await call.answer(text='❌ Rules were not added')
 
 
+async def help_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = None
+    user_lang = get_user_language(user_id) or 'en'
+    help_text = t(user_lang, 'help_info', helper=TgConfig.HELPER_URL)
+    await bot.edit_message_text(
+        help_text,
+        chat_id=call.message.chat.id,
+        message_id=call.message.message_id,
+        reply_markup=back('profile')
+    )
+
+
 async def profile_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     user = call.from_user
     TgConfig.STATE[user_id] = None
     user_info = check_user(user_id)
+    user_lang = user_info.language or 'en'
     balance = user_info.balance
     operations = select_user_operations(user_id)
     overall_balance = 0
@@ -834,7 +848,7 @@ async def profile_callback_handler(call: CallbackQuery):
             overall_balance += i
 
     items = select_user_items(user_id)
-    markup = profile(items)
+    markup = profile(items, user_lang)
     await bot.edit_message_text(text=f"👤 <b>Profile</b> — {user.first_name}\n🆔"
                                      f" <b>ID</b> — <code>{user_id}</code>\n"
                                      f"💳 <b>Balance</b> — <code>{balance}</code> €\n"
@@ -1127,6 +1141,8 @@ def register_user_handlers(dp: Dispatcher):
                                        lambda c: c.data == 'profile')
     dp.register_callback_query_handler(rules_callback_handler,
                                        lambda c: c.data == 'rules')
+    dp.register_callback_query_handler(help_callback_handler,
+                                       lambda c: c.data == 'help')
     dp.register_callback_query_handler(replenish_balance_callback_handler,
                                        lambda c: c.data == 'replenish_balance')
     dp.register_callback_query_handler(price_list_callback_handler,

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -108,13 +108,14 @@ def item_info(item_name: str, category_name: str, lang: str) -> InlineKeyboardMa
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 
-def profile(user_items: int = 0) -> InlineKeyboardMarkup:
+def profile(user_items: int = 0, lang: str = 'en') -> InlineKeyboardMarkup:
     inline_keyboard = [
         [InlineKeyboardButton('💸 Top up balance', callback_data='replenish_balance')]
     ]
     inline_keyboard.append([InlineKeyboardButton('🃏 Blackjack', callback_data='blackjack')])
     if user_items != 0:
         inline_keyboard.append([InlineKeyboardButton('🎁 Purchased items', callback_data='bought_items')])
+    inline_keyboard.append([InlineKeyboardButton(t(lang, 'help'), callback_data='help')])
     inline_keyboard.append([InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 

--- a/bot/localization.py
+++ b/bot/localization.py
@@ -10,6 +10,15 @@ LANGUAGES = {
         'price_list': '💲 Price List',
         'language': '🌐 Language',
         'admin_panel': '🎛 Admin Panel',
+        'help': '❓ Help',
+        'help_info': (
+            'Use the main menu buttons to navigate through the bot:\n'
+            '🛍 Shop – browse products.\n'
+            '👤 Profile – view your balance and purchases.\n'
+            '💸 Top Up – add funds to your balance.\n'
+            '🌐 Language – switch the interface language.\n'
+            'If you need assistance, contact {helper}.'
+        ),
         'choose_language': 'Please choose a language',
         'invoice_message': (
             '🧾 <b>Payment Invoice Created</b>\n\n'
@@ -57,6 +66,15 @@ LANGUAGES = {
         'price_list': '💲 Прайс-лист',
         'language': '🌐 Язык',
         'admin_panel': '🎛 Админ панель',
+        'help': '❓ Помощь',
+        'help_info': (
+            'Используйте кнопки главного меню для навигации по боту:\n'
+            '🛍 Магазин – просмотр товаров.\n'
+            '👤 Профиль – ваш баланс и покупки.\n'
+            '💸 Пополнить – добавить средства на баланс.\n'
+            '🌐 Язык – сменить язык интерфейса.\n'
+            'Если нужна помощь, обратитесь к {helper}.'
+        ),
         'choose_language': 'Пожалуйста, выберите язык',
         'invoice_message': (
             '🧾 <b>Создан инвойс на оплату</b>\n\n'
@@ -103,6 +121,15 @@ LANGUAGES = {
         'price_list': '💲 Kainoraštis',
         'language': '🌐 Kalba',
         'admin_panel': '🎛 Admin pultas',
+        'help': '❓ Pagalba',
+        'help_info': (
+            'Naudokite pagrindinio meniu mygtukus, kad naršytumėte botą:\n'
+            '🛍 Parduotuvė – peržiūrėti prekes.\n'
+            '👤 Profilis – matyti balansą ir pirkinius.\n'
+            '💸 Papildyti – įnešti lėšų į balansą.\n'
+            '🌐 Kalba – pakeisti sąsajos kalbą.\n'
+            'Jei reikia pagalbos, susisiekite su {helper}.'
+        ),
         'choose_language': 'Pasirinkite kalbą',
         'invoice_message': (
             '🧾 <b>Sukurta mokėjimo sąskaita</b>\n\n'


### PR DESCRIPTION
## Summary
- add Help button to profile menu
- show localized instructions and link to helper contact
- localize new strings in English, Russian, and Lithuanian

## Testing
- `pytest`
- `python -m py_compile bot/localization.py bot/keyboards/inline.py bot/handlers/user/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4c4ea51348332a56d55712e2937f4